### PR TITLE
Update client version

### DIFF
--- a/pcrclient.py
+++ b/pcrclient.py
@@ -18,7 +18,7 @@ defaultHeaders = {
     'Accept-Encoding' : 'gzip',
     'User-Agent' : 'Dalvik/2.1.0 (Linux, U, Android 5.1.1, PCRT00 Build/LMY48Z)',
     'X-Unity-Version' : '2018.4.30f1',
-    'APP-VER' : '3.4.8',
+    'APP-VER' : '3.4.9',
     'BATTLE-LOGIC-VERSION' : '4',
     'BUNDLE-VER' : '',
     'DEVICE' : '2',


### PR DESCRIPTION
2021年9月21日，B服客户端更新到3.4.9版本
（其实3.4.8现在还能用，不过还是改一下吧）